### PR TITLE
fix: skip unknown child elements in FlexQueryResponse instead of raising FlexParserError

### DIFF
--- a/ibflex/__version__.py
+++ b/ibflex/__version__.py
@@ -18,7 +18,7 @@ __description__ = (
     ("Parse Interactive Brokers Flex XML reports and convert to Python types"),
 )
 __url__ = "https://github.com/sanjifr3/ibflex"
-__version__ = "0.16.2"
+__version__ = "0.16.3"
 __author__ = "Christopher Singley"
 __author_email__ = "csingley@gmail.com"
 __license__ = "MIT"

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -130,49 +130,30 @@ def parse_data_element(elem: ET.Element) -> Types.FlexElement:
     #  Look up XML element's matching FlexElement subclass in ibflex.Types.
     Class = getattr(Types, elem.tag)
 
-    ## sanjifr3
-
-    # Added
-    #  Parse element attributes
+    #  Parse element attributes, skipping unknown ones with a warning.
     attrs = dict()
     for k, v in elem.attrib.items():
         try:
-            if k == "SLBCollaterals":
-                print(v)
             k, v = parse_element_attr(Class, k, v)
-            if k == "SLBCollaterals":
-                print(v)
             attrs[k] = v
         except KeyError as exc:
             msg = f"{Class.__name__} has no attribute " + str(exc)
             logger.warning(msg)
             continue
-    # \Added
-    # Removed
-    # try:
-    #     attrs = dict(parse_element_attr(Class, k, v) for k, v in elem.attrib.items())
-    # except KeyError as exc:
-    #     msg = f"{Class.__name__} has no attribute " + str(exc)
-    #     raise FlexParserError(msg)
-    # \Removed
 
     #  FlexQueryResponse & FlexStatement are the only data elements
-    #  that contain other data elements.
-    old_attrs = attrs.copy()
+    #  that contain other data elements.  Skip unknown child tags with a warning
+    #  (same policy as unknown attributes above).
     contained_elements = {child.tag: parse_element(child) for child in elem}
     if contained_elements:
         assert elem.tag in ("FlexQueryResponse", "FlexStatement")
-        attrs.update(contained_elements)
+        valid_fields = set(Class.__dataclass_fields__.keys())
+        for tag, value in contained_elements.items():
+            if tag in valid_fields:
+                attrs[tag] = value
+            else:
+                logger.warning(f"{Class.__name__} has no field for child element <{tag}>")
 
-    ## sanjifr3
-
-    # Added
-    # for key in ["SLBCollaterals", "AssetSummary"]:
-    #     if key in attrs:
-    #         try:
-    #             return Class(**attrs)
-    #         except Exception as exc:
-    #             del attrs[key]
     try:
         return Class(**attrs)
     except Exception as exc:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -123,6 +123,24 @@ class ParseDataElementTestCase(unittest.TestCase):
         #  Only FlexQueryResponse & FlexStatement may have contained elements.
         pass
 
+    def testUnknownChildElementIsSkipped(self):
+        """Unknown child elements in FlexQueryResponse are skipped with a warning.
+
+        IBKR sometimes includes a <Message> child element alongside <FlexStatements>.
+        The parser should skip unknown child tags (same as it does for unknown attributes)
+        rather than blowing up with a FlexParserError.
+        """
+        xml = (
+            b'<FlexQueryResponse queryName="TestQuery" type="AF">'
+            b'<FlexStatements count="0"></FlexStatements>'
+            b'<Message>Informational message from IBKR</Message>'
+            b'</FlexQueryResponse>'
+        )
+        # Should not raise FlexParserError
+        result = parser.parse(xml)
+        self.assertEqual(result.queryName, "TestQuery")
+        self.assertEqual(result.FlexStatements, ())
+
 
 class ParseElementAttrTestCase(unittest.TestCase):
     def testBasicType(self):


### PR DESCRIPTION
**Summary**

IBKR has started returning a `<Message>` child element inside `<FlexQueryResponse>` (e.g. informational notices alongside normal statement data). The parser was blindly passing all child element tags into `Class(**attrs)`, which caused:

```
ibflex.parser.FlexParserError: FlexQueryResponse - FlexQueryResponse.__init__() got an unexpected keyword argument 'Message'
```

**Description of Changes**

- `ibflex/parser.py`: In `parse_data_element`, filter `contained_elements` through `Class.__dataclass_fields__` before building the kwargs dict. Unknown child element tags are skipped with a `logger.warning` — consistent with how unknown XML *attributes* are already handled in the same function.
- Also removed leftover debug `print` statements and dead commented-out code from a previous edit.
- `tests/test_parser.py`: Added `testUnknownChildElementIsSkipped` — parses a `<FlexQueryResponse>` that includes a `<Message>` child and asserts no error is raised.

**Testing**

```
python -m pytest tests/test_parser.py::ParseDataElementTestCase::testUnknownChildElementIsSkipped -v
# PASSED
```

Full suite: 17 passing, 4 pre-existing failures in `ParseElementAttrTestCase` (unrelated to this change, reproduced on `master`).

**Change management (required)**
type=routine
risk=low
impact=sev5

**Automerge**
automerge=false